### PR TITLE
[FEAT] Recipes dataset ETL

### DIFF
--- a/recipes/recipes-etl.ipynb
+++ b/recipes/recipes-etl.ipynb
@@ -79,7 +79,7 @@
    "outputs": [],
    "source": [
     "from pyspark.sql.types import StructType, StructField, StringType, FloatType, IntegerType, ArrayType\n",
-    "from pyspark.sql.functions import split, regexp_replace, expr, lower, array_except, col, lit, array, transform, trim, filter, udf"
+    "from pyspark.sql.functions import size,split, regexp_replace, expr, lower, array_except, col, lit, array, transform, trim, filter, udf"
    ]
   },
   {
@@ -184,7 +184,7 @@
    "outputs": [],
    "source": [
     "exclusion = spark.read.csv(\n",
-    "    \"/Volumes/wine_harmonization/datasets/raw_datasets/ingredient_exclusion_lexicon.csv\",\n",
+    "    \"/Volumes/wine_harmonization/datasets/raw_datasets/ingredient_exclusion_lexicon_updated_v2.csv\",\n",
     "    header=True,\n",
     "    inferSchema=True,\n",
     "    comment='#'\n",
@@ -285,33 +285,6 @@
      },
      "inputWidgets": {},
      "nuid": "7dcf5183-6149-4701-812f-507b462b45a4",
-     "showTitle": false,
-     "tableResultSettingsMap": {},
-     "title": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "recipes_clean = (\n",
-    "    recipes_clean\n",
-    "    .withColumn(\"ingredients_list\", regexp_replace(\"ingredients_list\", r'[\\[\\]\\\"]', ''))\n",
-    "    .withColumn(\"ingredients_list\", split(\"ingredients_list\", \",\"))\n",
-    "    .withColumn(\"ingredients_list\", expr(\"transform(ingredients_list, x -> lower(x))\"))\n",
-    "    .withColumn(\"ingredients_list\", expr(\"transform(ingredients_list, x -> trim(x))\"))\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
-     "inputWidgets": {},
-     "nuid": "a164cba2-d279-4f77-8dba-1a3d83fc41ba",
      "showTitle": false,
      "tableResultSettingsMap": {},
      "title": ""
@@ -440,7 +413,7 @@
       "rowLimit": 10000
      },
      "inputWidgets": {},
-     "nuid": "1342f2c2-f4eb-4e2a-9aed-4b24d0fbf35d",
+     "nuid": "4c4236a8-025c-435f-adc4-b0897ad7b82b",
      "showTitle": false,
      "tableResultSettingsMap": {},
      "title": ""
@@ -448,6 +421,7 @@
    },
    "outputs": [],
    "source": [
+    "recipes = recipes.filter(size(col(\"ingredients_list\")) > 0)\n",
     "display(recipes.count())\n",
     "display(recipes)"
    ]
@@ -502,7 +476,7 @@
    "language": "python",
    "notebookMetadata": {
     "mostRecentlyExecutedCommandWithImplicitDF": {
-     "commandId": -1,
+     "commandId": 8504388393273756,
      "dataframes": [
       "_sqldf"
      ]

--- a/recipes/recipes-etl.ipynb
+++ b/recipes/recipes-etl.ipynb
@@ -420,7 +420,7 @@
    },
    "outputs": [],
    "source": [
-    "recipes = recipes.filter(size(col(\"ingredients_list\")) > 0)\n",
+    "recipes = recipes.filter(size(col(\"ingredients_list\")) > 2)\n",
     "display(recipes.count())\n",
     "display(recipes)"
    ]

--- a/recipes/recipes-etl.ipynb
+++ b/recipes/recipes-etl.ipynb
@@ -57,7 +57,8 @@
    },
    "outputs": [],
    "source": [
-    "from pyspark.sql.types import StructType, StructField, StringType, FloatType, IntegerType"
+    "from pyspark.sql.types import StructType, StructField, StringType, FloatType, IntegerType\n",
+    "from pyspark.sql.functions import split, regexp_replace"
    ]
   },
   {
@@ -174,6 +175,8 @@
     "    .dropna(subset=[\"title\", \"NER\"])\n",
     "    .withColumnRenamed(\"_c0\", \"id\")\n",
     "    .withColumnRenamed(\"NER\", \"ingredients_list\")\n",
+    "    .withColumn(\"ingredients_list\", regexp_replace(\"ingredients_list\", r'[\\[\\]\\\"]', ''))\n",
+    "    .withColumn(\"ingredients_list\", split(\"ingredients_list\", \",\"))\n",
     "    .dropDuplicates(subset=[\"title\"])\n",
     ")"
    ]

--- a/recipes/recipes-etl.ipynb
+++ b/recipes/recipes-etl.ipynb
@@ -49,6 +49,27 @@
       "rowLimit": 10000
      },
      "inputWidgets": {},
+     "nuid": "c8cefc0c-94d9-4e7c-bd9a-eff3ad6a4e24",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "dbutils.library.restartPython()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
      "nuid": "bbd2c729-b728-42a5-9bd0-a981d2812a62",
      "showTitle": true,
      "tableResultSettingsMap": {},
@@ -58,7 +79,7 @@
    "outputs": [],
    "source": [
     "from pyspark.sql.types import StructType, StructField, StringType, FloatType, IntegerType\n",
-    "from pyspark.sql.functions import split, regexp_replace"
+    "from pyspark.sql.functions import split, regexp_replace, expr, lower, array_except, col, lit, array, transform, trim, filter"
    ]
   },
   {
@@ -137,6 +158,74 @@
       "rowLimit": 10000
      },
      "inputWidgets": {},
+     "nuid": "d95e80c6-2149-4ffe-bfad-20b9bbfe11e6",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "### Load ingredient exclusion lexicon"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "d50d64f2-19ea-4e71-b622-04ccc0fe6fb5",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "exclusion = spark.read.csv(\n",
+    "    \"/Volumes/wine_harmonization/datasets/raw_datasets/ingredient_exclusion_lexicon.csv\",\n",
+    "    header=True,\n",
+    "    inferSchema=True,\n",
+    "    comment='#'\n",
+    ")\n",
+    "\n",
+    "exclusion = exclusion.withColumn(\"word\", lower(exclusion[\"word\"])).dropDuplicates(subset=[\"word\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "f7924525-29ee-44f2-a5c7-81c31dacffbb",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "display(exclusion)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
      "nuid": "f8a35b05-e82b-4f8f-9d5a-1bffc7b0e1ad",
      "showTitle": false,
      "tableResultSettingsMap": {},
@@ -165,20 +254,140 @@
    },
    "outputs": [],
    "source": [
-    "recipes = (\n",
-    "    raw_recipes.drop(\n",
-    "        \"link\",\n",
-    "        \"directions\",\n",
-    "        \"source\",\n",
-    "        \"ingredients\"\n",
-    "    )\n",
-    "    .dropna(subset=[\"title\", \"NER\"])\n",
-    "    .withColumnRenamed(\"_c0\", \"id\")\n",
-    "    .withColumnRenamed(\"NER\", \"ingredients_list\")\n",
+    "recipes_clean = raw_recipes.drop(\n",
+    "    \"link\", \"directions\", \"source\", \"ingredients\"\n",
+    ").dropna(subset=[\"title\", \"NER\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "ef7f432b-be56-4f05-b641-2d264c718c65",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "recipes_clean = recipes_clean.withColumnRenamed(\"_c0\", \"id\").withColumnRenamed(\"NER\", \"ingredients_list\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "7dcf5183-6149-4701-812f-507b462b45a4",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "recipes_clean = (\n",
+    "    recipes_clean\n",
     "    .withColumn(\"ingredients_list\", regexp_replace(\"ingredients_list\", r'[\\[\\]\\\"]', ''))\n",
     "    .withColumn(\"ingredients_list\", split(\"ingredients_list\", \",\"))\n",
-    "    .dropDuplicates(subset=[\"title\"])\n",
+    "    .withColumn(\"ingredients_list\", expr(\"transform(ingredients_list, x -> lower(x))\"))\n",
+    "    .withColumn(\"ingredients_list\", expr(\"transform(ingredients_list, x -> trim(x))\"))\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "a164cba2-d279-4f77-8dba-1a3d83fc41ba",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "exclusion_words = [row['word'] for row in exclusion.select(\"word\").distinct().collect()]\n",
+    "print(\"Palavras para exclusão:\", exclusion_words)\n",
+    "\n",
+    "pattern = '|'.join([f'\\\\b{word}\\\\b' for word in exclusion_words])\n",
+    "print(\"Pattern criado:\", pattern)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "9417b1c5-8c7b-4f8a-80ee-f87d83e29d02",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "recipes_clean = (\n",
+    "    recipes_clean\n",
+    "    .withColumn(\n",
+    "        \"valid_ingredients\",\n",
+    "        expr(\"\"\"\n",
+    "            size(\n",
+    "                filter(\n",
+    "                    ingredients_list,\n",
+    "                    x -> \n",
+    "                        x rlike '^[a-z]'\n",
+    "                )\n",
+    "            ) = size(ingredients_list)\n",
+    "        \"\"\")\n",
+    "    )\n",
+    "    .filter(\"valid_ingredients\")\n",
+    "    .drop(\"valid_ingredients\")\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "3b5fa337-ace3-403b-8312-88805a3b1ed7",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "recipes = recipes_clean.dropDuplicates(subset=[\"title\"])"
    ]
   },
   {
@@ -255,6 +464,12 @@
    "inputWidgetPreferences": null,
    "language": "python",
    "notebookMetadata": {
+    "mostRecentlyExecutedCommandWithImplicitDF": {
+     "commandId": -1,
+     "dataframes": [
+      "_sqldf"
+     ]
+    },
     "pythonIndentUnit": 4
    },
    "notebookName": "recipes-etl",

--- a/recipes/recipes-etl.ipynb
+++ b/recipes/recipes-etl.ipynb
@@ -1,13 +1,177 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "cee0a009-dbc7-499e-b7c6-c0496b0e026a",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## ETL Recipes\n",
+    "add description "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "b7af4c52-11bb-4412-a51c-fbab88429e9e",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "### Initial configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "bbd2c729-b728-42a5-9bd0-a981d2812a62",
+     "showTitle": true,
+     "tableResultSettingsMap": {},
+     "title": "imports"
+    }
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "fcb2cba1-0c7f-48d8-afd2-241f32054dba",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "### Load recipes dataset in a Dataframe"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {},
      "inputWidgets": {},
-     "nuid": "bbd2c729-b728-42a5-9bd0-a981d2812a62",
+     "nuid": "b06d7bfd-e372-4e7b-a05e-d6f45d2fefa8",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "4d9534c8-774f-4ea6-a41c-b90e5ec416a9",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "### Clean rows"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "f68dde0e-5cbc-44b5-ad49-81b340367dbf",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "63266cc8-8b83-42fb-8273-06b84a1e2f86",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "### Split ingredients"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "7b58ab85-0ecd-4aef-9d29-05f9c4af52df",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "490c3fe8-1814-463a-8b4c-43038f446697",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "### Save in a table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "eea50d54-3ab6-439a-a8a1-ce46be1c33e4",
      "showTitle": false,
      "tableResultSettingsMap": {},
      "title": ""

--- a/recipes/recipes-etl.ipynb
+++ b/recipes/recipes-etl.ipynb
@@ -4,7 +4,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "cee0a009-dbc7-499e-b7c6-c0496b0e026a",
      "showTitle": false,
@@ -21,7 +24,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "b7af4c52-11bb-4412-a51c-fbab88429e9e",
      "showTitle": false,
@@ -50,13 +56,18 @@
     }
    },
    "outputs": [],
-   "source": []
+   "source": [
+    "from pyspark.sql.types import StructType, StructField, StringType, FloatType, IntegerType"
+   ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "fcb2cba1-0c7f-48d8-afd2-241f32054dba",
      "showTitle": false,
@@ -73,24 +84,59 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
-     "nuid": "b06d7bfd-e372-4e7b-a05e-d6f45d2fefa8",
+     "nuid": "d6e0174b-6a5e-4a94-a3ce-9becdfa981cd",
      "showTitle": false,
      "tableResultSettingsMap": {},
      "title": ""
     }
    },
    "outputs": [],
-   "source": []
+   "source": [
+    "raw_recipes = spark.read.csv(\n",
+    "    \"/Volumes/wine_harmonization/datasets/raw_datasets/RecipeNLG_dataset.csv\",\n",
+    "    header=True,\n",
+    "    inferSchema=True,\n",
+    "    escape='\"'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "3e7d6060-cdd8-4af2-9ed8-5675daa12bb2",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "display(raw_recipes.count())\n",
+    "display(raw_recipes)"
+   ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
-     "nuid": "4d9534c8-774f-4ea6-a41c-b90e5ec416a9",
+     "nuid": "f8a35b05-e82b-4f8f-9d5a-1bffc7b0e1ad",
      "showTitle": false,
      "tableResultSettingsMap": {},
      "title": ""
@@ -105,31 +151,31 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
-     "nuid": "f68dde0e-5cbc-44b5-ad49-81b340367dbf",
+     "nuid": "df386f76-78de-4cb4-a9c8-0736763add7e",
      "showTitle": false,
      "tableResultSettingsMap": {},
      "title": ""
     }
    },
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
-     "inputWidgets": {},
-     "nuid": "63266cc8-8b83-42fb-8273-06b84a1e2f86",
-     "showTitle": false,
-     "tableResultSettingsMap": {},
-     "title": ""
-    }
-   },
    "source": [
-    "### Split ingredients"
+    "recipes = (\n",
+    "    raw_recipes.drop(\n",
+    "        \"link\",\n",
+    "        \"directions\",\n",
+    "        \"source\",\n",
+    "        \"ingredients\"\n",
+    "    )\n",
+    "    .dropna(subset=[\"title\", \"NER\"])\n",
+    "    .withColumnRenamed(\"_c0\", \"id\")\n",
+    "    .withColumnRenamed(\"NER\", \"ingredients_list\")\n",
+    "    .dropDuplicates(subset=[\"title\"])\n",
+    ")"
    ]
   },
   {
@@ -137,22 +183,31 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
-     "nuid": "7b58ab85-0ecd-4aef-9d29-05f9c4af52df",
+     "nuid": "1342f2c2-f4eb-4e2a-9aed-4b24d0fbf35d",
      "showTitle": false,
      "tableResultSettingsMap": {},
      "title": ""
     }
    },
    "outputs": [],
-   "source": []
+   "source": [
+    "display(recipes.count())\n",
+    "display(recipes)"
+   ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "490c3fe8-1814-463a-8b4c-43038f446697",
      "showTitle": false,
@@ -169,7 +224,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "eea50d54-3ab6-439a-a8a1-ce46be1c33e4",
      "showTitle": false,
@@ -178,7 +236,9 @@
     }
    },
    "outputs": [],
-   "source": []
+   "source": [
+    "recipes.write.mode(\"overwrite\").saveAsTable(\"wine_harmonization.datasets.recipes\")"
+   ]
   }
  ],
  "metadata": {

--- a/recipes/recipes-etl.ipynb
+++ b/recipes/recipes-etl.ipynb
@@ -78,8 +78,8 @@
    },
    "outputs": [],
    "source": [
-    "from pyspark.sql.types import StructType, StructField, StringType, FloatType, IntegerType\n",
-    "from pyspark.sql.functions import split, regexp_replace, expr, lower, array_except, col, lit, array, transform, trim, filter"
+    "from pyspark.sql.types import StructType, StructField, StringType, FloatType, IntegerType, ArrayType\n",
+    "from pyspark.sql.functions import split, regexp_replace, expr, lower, array_except, col, lit, array, transform, trim, filter, udf"
    ]
   },
   {
@@ -153,10 +153,7 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
+     "cellMetadata": {},
      "inputWidgets": {},
      "nuid": "d95e80c6-2149-4ffe-bfad-20b9bbfe11e6",
      "showTitle": false,
@@ -221,10 +218,7 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
+     "cellMetadata": {},
      "inputWidgets": {},
      "nuid": "f8a35b05-e82b-4f8f-9d5a-1bffc7b0e1ad",
      "showTitle": false,
@@ -326,10 +320,35 @@
    "outputs": [],
    "source": [
     "exclusion_words = [row['word'] for row in exclusion.select(\"word\").distinct().collect()]\n",
-    "print(\"Palavras para exclusão:\", exclusion_words)\n",
     "\n",
-    "pattern = '|'.join([f'\\\\b{word}\\\\b' for word in exclusion_words])\n",
-    "print(\"Pattern criado:\", pattern)"
+    "def remove_excluded_words(ingredients_list, exclusion_set):\n",
+    "    if not ingredients_list:\n",
+    "        return []\n",
+    "    \n",
+    "    result = []\n",
+    "    for ingredient in ingredients_list:\n",
+    "        if ingredient:\n",
+    "            # Remover palavras da exclusão\n",
+    "            words = ingredient.split()\n",
+    "            filtered_words = [word for word in words if word not in exclusion_set]\n",
+    "            filtered_ingredient = ' '.join(filtered_words).strip()\n",
+    "            \n",
+    "            if filtered_ingredient:\n",
+    "                result.append(filtered_ingredient)\n",
+    "    \n",
+    "    return result\n",
+    "\n",
+    "exclusion_set = set(exclusion_words)\n",
+    "\n",
+    "remove_excluded_udf = udf(lambda ingredients: remove_excluded_words(ingredients, exclusion_set), ArrayType(StringType()))\n",
+    "\n",
+    "recipes_clean_test = (\n",
+    "    recipes_clean\n",
+    "    .withColumn(\"ingredients_list\", regexp_replace(\"ingredients_list\", r'[\\[\\]\\\"]', ''))\n",
+    "    .withColumn(\"ingredients_list\", split(\"ingredients_list\", \",\"))\n",
+    "    .withColumn(\"ingredients_list\", expr(\"transform(ingredients_list, x -> lower(trim(x)))\"))\n",
+    "    .withColumn(\"ingredients_list\", remove_excluded_udf(col(\"ingredients_list\")))\n",
+    ")"
    ]
   },
   {
@@ -350,8 +369,29 @@
    },
    "outputs": [],
    "source": [
+    "recipes_clean_test.write.mode(\"overwrite\").saveAsTable(\"wine_harmonization.datasets.recipes_clean\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "3b5fa337-ace3-403b-8312-88805a3b1ed7",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
     "recipes_clean = (\n",
-    "    recipes_clean\n",
+    "    recipes_clean_test\n",
     "    .withColumn(\n",
     "        \"valid_ingredients\",\n",
     "        expr(\"\"\"\n",
@@ -379,7 +419,7 @@
       "rowLimit": 10000
      },
      "inputWidgets": {},
-     "nuid": "3b5fa337-ace3-403b-8312-88805a3b1ed7",
+     "nuid": "40f6f110-dc4a-47c6-a949-630cd3c1166c",
      "showTitle": false,
      "tableResultSettingsMap": {},
      "title": ""
@@ -416,10 +456,7 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
+     "cellMetadata": {},
      "inputWidgets": {},
      "nuid": "490c3fe8-1814-463a-8b4c-43038f446697",
      "showTitle": false,
@@ -449,7 +486,7 @@
    },
    "outputs": [],
    "source": [
-    "recipes.write.mode(\"overwrite\").saveAsTable(\"wine_harmonization.datasets.recipes\")"
+    "#recipes.write.mode(\"overwrite\").saveAsTable(\"wine_harmonization.datasets.recipes\")"
    ]
   }
  ],

--- a/recipes/recipes-etl.ipynb
+++ b/recipes/recipes-etl.ipynb
@@ -153,7 +153,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "d95e80c6-2149-4ffe-bfad-20b9bbfe11e6",
      "showTitle": false,
@@ -184,13 +187,13 @@
    "outputs": [],
    "source": [
     "exclusion = spark.read.csv(\n",
-    "    \"/Volumes/wine_harmonization/datasets/raw_datasets/ingredient_exclusion_lexicon_updated_v2.csv\",\n",
+    "    \"/Volumes/wine_harmonization/datasets/raw_datasets/ingredients_inclusion.csv\",\n",
     "    header=True,\n",
     "    inferSchema=True,\n",
     "    comment='#'\n",
     ")\n",
     "\n",
-    "exclusion = exclusion.withColumn(\"word\", lower(exclusion[\"word\"])).dropDuplicates(subset=[\"word\"])"
+    "exclusion = exclusion.withColumn(\"entity_alias_readable\", lower(exclusion[\"entity_alias_readable\"])).dropDuplicates(subset=[\"entity_alias_readable\"])"
    ]
   },
   {
@@ -205,7 +208,14 @@
      "inputWidgets": {},
      "nuid": "f7924525-29ee-44f2-a5c7-81c31dacffbb",
      "showTitle": false,
-     "tableResultSettingsMap": {},
+     "tableResultSettingsMap": {
+      "0": {
+       "dataGridStateBlob": "{\"version\":1,\"tableState\":{\"columnPinning\":{\"left\":[\"#row_number#\"],\"right\":[]},\"columnSizing\":{},\"columnVisibility\":{}},\"settings\":{\"columns\":{}},\"syncTimestamp\":1752609580143}",
+       "filterBlob": null,
+       "queryPlanFiltersBlob": null,
+       "tableResultIndex": 0
+      }
+     },
      "title": ""
     }
    },
@@ -218,7 +228,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "f8a35b05-e82b-4f8f-9d5a-1bffc7b0e1ad",
      "showTitle": false,
@@ -271,7 +284,8 @@
    },
    "outputs": [],
    "source": [
-    "recipes_clean = recipes_clean.withColumnRenamed(\"_c0\", \"id\").withColumnRenamed(\"NER\", \"ingredients_list\")"
+    "recipes_clean = recipes_clean.withColumnRenamed(\"_c0\", \"id\").withColumnRenamed(\"NER\", \"ingredients_list\")\n",
+    "display(recipes_clean)"
    ]
   },
   {
@@ -292,7 +306,7 @@
    },
    "outputs": [],
    "source": [
-    "exclusion_words = [row['word'] for row in exclusion.select(\"word\").distinct().collect()]\n",
+    "exclusion_words = [row['entity_alias_readable'] for row in exclusion.select(\"entity_alias_readable\").distinct().collect()]\n",
     "\n",
     "def remove_excluded_words(ingredients_list, exclusion_set):\n",
     "    if not ingredients_list:\n",
@@ -301,9 +315,8 @@
     "    result = []\n",
     "    for ingredient in ingredients_list:\n",
     "        if ingredient:\n",
-    "            # Remover palavras da exclusão\n",
     "            words = ingredient.split()\n",
-    "            filtered_words = [word for word in words if word not in exclusion_set]\n",
+    "            filtered_words = [word for word in words if word in exclusion_set]\n",
     "            filtered_ingredient = ' '.join(filtered_words).strip()\n",
     "            \n",
     "            if filtered_ingredient:\n",
@@ -322,27 +335,6 @@
     "    .withColumn(\"ingredients_list\", expr(\"transform(ingredients_list, x -> lower(trim(x)))\"))\n",
     "    .withColumn(\"ingredients_list\", remove_excluded_udf(col(\"ingredients_list\")))\n",
     ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
-     "inputWidgets": {},
-     "nuid": "9417b1c5-8c7b-4f8a-80ee-f87d83e29d02",
-     "showTitle": false,
-     "tableResultSettingsMap": {},
-     "title": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "recipes_clean_test.write.mode(\"overwrite\").saveAsTable(\"wine_harmonization.datasets.recipes_clean\")"
    ]
   },
   {
@@ -415,7 +407,14 @@
      "inputWidgets": {},
      "nuid": "4c4236a8-025c-435f-adc4-b0897ad7b82b",
      "showTitle": false,
-     "tableResultSettingsMap": {},
+     "tableResultSettingsMap": {
+      "0": {
+       "dataGridStateBlob": "{\"version\":1,\"tableState\":{\"columnPinning\":{\"left\":[\"#row_number#\"],\"right\":[]},\"columnSizing\":{},\"columnVisibility\":{}},\"settings\":{\"columns\":{}},\"syncTimestamp\":1752610517671}",
+       "filterBlob": null,
+       "queryPlanFiltersBlob": null,
+       "tableResultIndex": 0
+      }
+     },
      "title": ""
     }
    },
@@ -430,7 +429,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "490c3fe8-1814-463a-8b4c-43038f446697",
      "showTitle": false,
@@ -460,7 +462,7 @@
    },
    "outputs": [],
    "source": [
-    "#recipes.write.mode(\"overwrite\").saveAsTable(\"wine_harmonization.datasets.recipes\")"
+    "recipes.write.mode(\"overwrite\").saveAsTable(\"wine_harmonization.datasets.recipes\")"
    ]
   }
  ],

--- a/recipes/recipes-etl.ipynb
+++ b/recipes/recipes-etl.ipynb
@@ -1,0 +1,42 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "bbd2c729-b728-42a5-9bd0-a981d2812a62",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "computePreferences": null,
+   "dashboards": [],
+   "environmentMetadata": {
+    "base_environment": "",
+    "environment_version": "2"
+   },
+   "inputWidgetPreferences": null,
+   "language": "python",
+   "notebookMetadata": {
+    "pythonIndentUnit": 4
+   },
+   "notebookName": "recipes-etl",
+   "widgets": {}
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
## Overview

The recipe_etl script reads and loads the recipes file into a dataframe. It also loads the flavors file and removes any recipes that don’t have at least three matching ingredients. Finally, it inserts the remaining recipes into a table.