### PR TITLE
[FEAT] Wines dataset ETL

### DIFF
--- a/wine/wine-etl.ipynb
+++ b/wine/wine-etl.ipynb
@@ -1,0 +1,495 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "cee0a009-dbc7-499e-b7c6-c0496b0e026a",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## ETL Wine\n",
+    "add description "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "b7af4c52-11bb-4412-a51c-fbab88429e9e",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "### Initial configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "c8cefc0c-94d9-4e7c-bd9a-eff3ad6a4e24",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "dbutils.library.restartPython()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "bbd2c729-b728-42a5-9bd0-a981d2812a62",
+     "showTitle": true,
+     "tableResultSettingsMap": {},
+     "title": "imports"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from pyspark.sql.types import StructType, StructField, StringType, FloatType, IntegerType, ArrayType\n",
+    "from pyspark.sql.functions import size,split, regexp_replace, expr, lower, array_except, col, lit, array, transform, trim, filter, udf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "fcb2cba1-0c7f-48d8-afd2-241f32054dba",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "### Load wine dataset in a Dataframe"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "d6e0174b-6a5e-4a94-a3ce-9becdfa981cd",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "raw_wine = spark.read.csv(\n",
+    "    \"/Volumes/wine_harmonization/datasets/raw_datasets/WineDataset.csv\",\n",
+    "    header=True,\n",
+    "    inferSchema=True,\n",
+    "    escape='\"'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "3e7d6060-cdd8-4af2-9ed8-5675daa12bb2",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "display(raw_wine.count())\n",
+    "display(raw_wine)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "1c378c12-a8bf-4c01-bdd3-2f1a4a696ef0",
+     "showTitle": false,
+     "tableResultSettingsMap": {
+      "0": {
+       "dataGridStateBlob": "{\"version\":1,\"tableState\":{\"columnPinning\":{\"left\":[\"#row_number#\"],\"right\":[]},\"columnSizing\":{},\"columnVisibility\":{}},\"settings\":{\"columns\":{}},\"syncTimestamp\":1752623350373}",
+       "filterBlob": null,
+       "queryPlanFiltersBlob": null,
+       "tableResultIndex": 0
+      }
+     },
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "exclusion = spark.read.csv(\n",
+    "    \"/Volumes/wine_harmonization/datasets/raw_datasets/unique_flavors.csv\",\n",
+    "    header=True,\n",
+    "    inferSchema=True,\n",
+    "    comment='#'\n",
+    ")\n",
+    "\n",
+    "exclusion = exclusion.withColumn(\"flavor\", lower(exclusion[\"flavor\"])).dropDuplicates(subset=[\"flavor\"])\n",
+    "display(exclusion)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "f8a35b05-e82b-4f8f-9d5a-1bffc7b0e1ad",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "### Clean rows"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "df386f76-78de-4cb4-a9c8-0736763add7e",
+     "showTitle": false,
+     "tableResultSettingsMap": {
+      "0": {
+       "dataGridStateBlob": "{\"version\":1,\"tableState\":{\"columnPinning\":{\"left\":[\"#row_number#\"],\"right\":[]},\"columnSizing\":{},\"columnVisibility\":{}},\"settings\":{\"columns\":{}},\"syncTimestamp\":1752615525783}",
+       "filterBlob": null,
+       "queryPlanFiltersBlob": null,
+       "tableResultIndex": 0
+      }
+     },
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "wines_clean = raw_wine.drop(\n",
+    "    \"Appellation\", \"Vintage\", \"Style\", \"Region\", \"ABV\", \"Description\", \"Closure\", \"Secondary Grape Varieties\", \"Unit\", \"Per bottle / case / each\", \"Capacity\", \"Country\"\n",
+    ").dropna(subset=[\"Title\", \"Grape\", \"Characteristics\", \"Price\", \"Type\"])\n",
+    "display(wines_clean)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "c28577a7-3e07-4b53-9c6f-9b221c85dcce",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from pyspark.sql import functions as F\n",
+    "\n",
+    "wines_filtered = wines_clean.filter(\n",
+    "    F.col(\"Type\").isin([\"Red\", \"White\", \"Rosé\"])\n",
+    ")\n",
+    "\n",
+    "display(wines_filtered)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "ef7f432b-be56-4f05-b641-2d264c718c65",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "wines_clean = wines_clean.withColumnRenamed(\"_c0\", \"id\").withColumnRenamed(\"NER\", \"Characteristics\")\n",
+    "display(wines_clean)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "7dcf5183-6149-4701-812f-507b462b45a4",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "exclusion_words = [row['flavor'] for row in exclusion.select(\"flavor\").distinct().collect()]\n",
+    "\n",
+    "def remove_excluded_words(Characteristics, exclusion_set):\n",
+    "    if not Characteristics:\n",
+    "        return []\n",
+    "    \n",
+    "    result = []\n",
+    "    for ingredient in Characteristics:\n",
+    "        if ingredient:\n",
+    "            words = ingredient.split()\n",
+    "            filtered_words = [word for word in words if word in exclusion_set]\n",
+    "            filtered_ingredient = ' '.join(filtered_words).strip()\n",
+    "            \n",
+    "            if filtered_ingredient:\n",
+    "                result.append(filtered_ingredient)\n",
+    "    \n",
+    "    return result\n",
+    "\n",
+    "exclusion_set = set(exclusion_words)\n",
+    "\n",
+    "remove_excluded_udf = udf(lambda ingredients: remove_excluded_words(ingredients, exclusion_set), ArrayType(StringType()))\n",
+    "\n",
+    "wines_clean_test = (\n",
+    "    wines_filtered\n",
+    "    .withColumn(\"Characteristics\", regexp_replace(\"Characteristics\", r'[\\[\\]\\\"]', ''))\n",
+    "    .withColumn(\"Characteristics\", split(\"Characteristics\", \",\"))\n",
+    "    .withColumn(\"Characteristics\", expr(\"transform(Characteristics, x -> lower(trim(x)))\"))\n",
+    "    .withColumn(\"Characteristics\", remove_excluded_udf(col(\"Characteristics\")))\n",
+    ")\n",
+    "display(wines_clean_test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "1a05ee53-1013-4a06-880d-d59f7675ba40",
+     "showTitle": false,
+     "tableResultSettingsMap": {
+      "0": {
+       "dataGridStateBlob": "{\"version\":1,\"tableState\":{\"columnPinning\":{\"left\":[\"#row_number#\"],\"right\":[]},\"columnSizing\":{\"Price\":141},\"columnVisibility\":{}},\"settings\":{\"columns\":{}},\"syncTimestamp\":1752626518178}",
+       "filterBlob": null,
+       "queryPlanFiltersBlob": null,
+       "tableResultIndex": 0
+      }
+     },
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from pyspark.sql import functions as F\n",
+    "\n",
+    "# Supondo que seu DataFrame seja wines_clean e a coluna se chame \"Characteristics\"\n",
+    "wines_no_dups = wines_clean_test.withColumn(\n",
+    "    \"Characteristics\",\n",
+    "    F.array_distinct(F.col(\"Characteristics\"))\n",
+    ")\n",
+    "\n",
+    "display(wines_no_dups)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "897ae333-4caf-4905-8876-8fc19b4c5c74",
+     "showTitle": false,
+     "tableResultSettingsMap": {
+      "0": {
+       "dataGridStateBlob": "{\"version\":1,\"tableState\":{\"columnPinning\":{\"left\":[\"#row_number#\"],\"right\":[]},\"columnSizing\":{},\"columnVisibility\":{}},\"settings\":{\"columns\":{}},\"syncTimestamp\":1752627152269}",
+       "filterBlob": null,
+       "queryPlanFiltersBlob": null,
+       "tableResultIndex": 0
+      }
+     },
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from pyspark.sql import functions as F\n",
+    "from pyspark.sql.types import FloatType\n",
+    "\n",
+    "# Cotação GBP→BRL (ajuste conforme necessário)\n",
+    "gbp_to_brl = 7.44\n",
+    "\n",
+    "wines_final = (\n",
+    "    wines_no_dups\n",
+    "    # normalização e extração do float\n",
+    "    .withColumn(\n",
+    "        \"price_str\",\n",
+    "        F.when(F.col(\"Price\").startswith(\"£\"), F.col(\"Price\"))\n",
+    "         .otherwise(None)\n",
+    "    )\n",
+    "    .withColumn(\"price_norm\",    F.regexp_replace(\"price_str\", \",\", \".\"))\n",
+    "    .withColumn(\"price_clean\",   F.regexp_replace(\"price_norm\", \"[^0-9\\\\.]\", \"\"))\n",
+    "    .withColumn(\"price_float\",   F.col(\"price_clean\").cast(FloatType()))\n",
+    "    # cálculo e arredondamento em reais\n",
+    "    .withColumn(\"price_brl\",     F.round(F.col(\"price_float\") * F.lit(gbp_to_brl), 2))\n",
+    "    # remove todas as colunas intermediárias e a original\n",
+    "    .drop(\"Price\", \"price_str\", \"price_norm\", \"price_clean\", \"price_float\")\n",
+    "    # renomeia price_brl para Price (ou outro nome que preferir)\n",
+    "    .withColumnRenamed(\"price_brl\", \"Price\")\n",
+    ")\n",
+    "\n",
+    "display(wines_final)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "490c3fe8-1814-463a-8b4c-43038f446697",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "### Save in a table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "eea50d54-3ab6-439a-a8a1-ce46be1c33e4",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "wines_final.write.mode(\"overwrite\").saveAsTable(\"wine_harmonization.datasets.wines\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "computePreferences": null,
+   "dashboards": [],
+   "environmentMetadata": {
+    "base_environment": "",
+    "environment_version": "2"
+   },
+   "inputWidgetPreferences": null,
+   "language": "python",
+   "notebookMetadata": {
+    "mostRecentlyExecutedCommandWithImplicitDF": {
+     "commandId": 8023300932153793,
+     "dataframes": [
+      "_sqldf"
+     ]
+    },
+    "pythonIndentUnit": 4
+   },
+   "notebookName": "wine-etl",
+   "widgets": {}
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
## Overview

The wine‑etl process reads the wine dataset into a DataFrame, then reads the unique_flavors file and filters out any wine characteristics that aren’t in that list. It removes duplicate records, converts prices from British pounds to Brazilian reais, and splits the characteristic strings into arrays. Finally, it writes the cleaned data into a table.
